### PR TITLE
removed getRefPathValue from prototype

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,6 @@ function deref(schema) {
   return derefSchema(schema);
 }
 
-deref.prototype.getRefPathValue = utils.getRefPathValue;
+deref.getRefPathValue = utils.getRefPathValue;
 
 module.exports = deref;


### PR DESCRIPTION
since there's no instancing this should be just an utility method of deref
